### PR TITLE
Add testing docs generated by test-metadata-generator plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,3 +78,10 @@ During failures all logs relevant logs are collected and stored in `target/logs`
 As part of `target/logs` you can find file `config.yaml` that contains all env variables used by the test run. 
 You can easily re-use it by pass path to the file into `ENV_FILE` environment variable. 
 Note that we suggest to copy the file outside the target dir.
+
+## Testing docs
+We are using [test-metadata-generator](https://github.com/skodjob/test-metadata-generator) maven plugin for annotating tests and generate test documentation from it.
+The docs are generated with every build and the changes should be committed when there are some.
+
+The plugin is still under development so the format could change.
+For more info see the plugin repository on GitHub.

--- a/docs/md/io/odh/test/e2e/standard/DataScienceClusterST.md
+++ b/docs/md/io/odh/test/e2e/standard/DataScienceClusterST.md
@@ -1,0 +1,43 @@
+# DataScienceClusterST
+
+**Description:** Verifies simple setup of ODH by spin-up operator, setup DSCI, and setup DSC.
+
+**Before tests execution steps:**
+
+| Step | Action | Result |
+| - | - | - |
+| 1. | Deploy Pipelines Operator | Pipelines operator is available on the cluster |
+| 2. | Deploy ServiceMesh Operator | ServiceMesh operator is available on the cluster |
+| 3. | Deploy Serverless Operator | Serverless operator is available on the cluster |
+| 4. | Install ODH operator | Operator is up and running and is able to serve it's operands |
+
+**After tests execution steps:**
+
+| Step | Action | Result |
+| - | - | - |
+| 1. | Delete ODH operator and all created resources | Operator is removed and all other resources as well |
+
+**Tags:**
+
+* `smoke`
+
+<hr style="border:1px solid">
+
+## createDataScienceCluster
+
+**Description:** Creates default DSCI and DSC and see if operator configure everything properly. Check that operator set status of the resources properly.
+
+**Contact:** `David Kornel <dkornel@redhat.com>`
+
+**Steps:**
+
+| Step | Action | Result |
+| - | - | - |
+| 1. | Create default DSCI | DSCI is created and ready |
+| 2. | Create default DSC | DSC is created and ready |
+| 3. | Check that DSC has expected states for all components | DSC status is set properly based on configuration |
+
+**Tags:**
+
+* `smoke`
+

--- a/docs/md/io/odh/test/e2e/standard/NotebookST.md
+++ b/docs/md/io/odh/test/e2e/standard/NotebookST.md
@@ -1,0 +1,38 @@
+# NotebookST
+
+**Description:** Verifies deployments of Notebooks via GitOps approach
+
+**Before tests execution steps:**
+
+| Step | Action | Result |
+| - | - | - |
+| 1. | Deploy Pipelines Operator | Pipelines operator is available on the cluster |
+| 2. | Deploy ServiceMesh Operator | ServiceMesh operator is available on the cluster |
+| 3. | Deploy Serverless Operator | Serverless operator is available on the cluster |
+| 4. | Install ODH operator | Operator is up and running and is able to serve it's operands |
+| 5. | Deploy DSCI | DSCI is created and ready |
+| 6. | Deploy DSC | DSC is created and ready |
+
+**After tests execution steps:**
+
+| Step | Action | Result |
+| - | - | - |
+| 1. | Delete ODH operator and all created resources | Operator is removed and all other resources as well |
+
+<hr style="border:1px solid">
+
+## testCreateSimpleNotebook
+
+**Description:** Create simple Notebook with all needed resources and see if Operator creates it properly
+
+**Contact:** `Jakub Stejskal <jstejska@redhat.com>`
+
+**Steps:**
+
+| Step | Action | Result |
+| - | - | - |
+| 1. | Create namespace for Notebook resources with proper name, labels and annotations | Namespace is created |
+| 2. | Create PVC with proper labels and data for Notebook | PVC is created |
+| 3. | Create Notebook resource with Pytorch image in pre-defined namespace | Notebook resource is created |
+| 4. | Wait for Notebook pods readiness | Notebook pods are up and running, Notebook is in ready state |
+

--- a/docs/md/io/odh/test/e2e/standard/PipelineServerST.md
+++ b/docs/md/io/odh/test/e2e/standard/PipelineServerST.md
@@ -1,0 +1,44 @@
+# PipelineServerST
+
+**Description:** Verifies simple setup of ODH by spin-up operator, setup DSCI, and setup DSC.
+
+**Before tests execution steps:**
+
+| Step | Action | Result |
+| - | - | - |
+| 1. | Deploy Pipelines Operator | Pipelines operator is available on the cluster |
+| 2. | Deploy ServiceMesh Operator | ServiceMesh operator is available on the cluster |
+| 3. | Deploy Serverless Operator | Serverless operator is available on the cluster |
+| 4. | Install ODH operator | Operator is up and running and is able to serve it's operands |
+| 5. | Deploy DSCI | DSCI is created and ready |
+| 6. | Deploy DSC | DSC is created and ready |
+
+**After tests execution steps:**
+
+| Step | Action | Result |
+| - | - | - |
+| 1. | Delete ODH operator and all created resources | Operator is removed and all other resources as well |
+
+<hr style="border:1px solid">
+
+## testUserCanCreateRunAndDeleteADSPipelineFromDSProject
+
+**Description:** Check that user can create, run and deleted DataSciencePipeline from a DataScience project
+
+**Contact:** `Jiri Danek <jdanek@redhat.com>`
+
+**Steps:**
+
+| Step | Action | Result |
+| - | - | - |
+| 1. | Create namespace for DataSciencePipelines application with proper name, labels and annotations | Namespace is created |
+| 2. | Create Minio secret with proper data for access s3 | Secret is created |
+| 3. | Create DataSciencePipelines application with configuration for new Minio instance and new MariaDB instance | Notebook resource is created |
+| 4. | Wait for DataSciencePipelines server readiness | DSPA endpoint is available and it return proper data |
+| 5. | Import pipeline to a pipeline server via API | Pipeline is imported |
+| 6. | List imported pipeline via API | Server return list with imported pipeline info |
+| 7. | Trigger pipeline run for imported pipeline | Pipeline is triggered |
+| 8. | Wait for pipeline success | Pipeline succeeded |
+| 9. | Delete pipeline run | Pipeline run is deleted |
+| 10. | Delete pipeline | Pipeline is deleted |
+

--- a/docs/md/io/odh/test/e2e/standard/PipelineServerST.md
+++ b/docs/md/io/odh/test/e2e/standard/PipelineServerST.md
@@ -33,8 +33,8 @@
 | - | - | - |
 | 1. | Create namespace for DataSciencePipelines application with proper name, labels and annotations | Namespace is created |
 | 2. | Create Minio secret with proper data for access s3 | Secret is created |
-| 3. | Create DataSciencePipelines application with configuration for new Minio instance and new MariaDB instance | Notebook resource is created |
-| 4. | Wait for DataSciencePipelines server readiness | DSPA endpoint is available and it return proper data |
+| 3. | Create DataSciencePipelinesApplication with configuration for new Minio instance and new MariaDB instance | DataSciencePipelinesApplication resource is created |
+| 4. | Wait for DataSciencePipelines server readiness | DSP API endpoint is available and it return proper data |
 | 5. | Import pipeline to a pipeline server via API | Pipeline is imported |
 | 6. | List imported pipeline via API | Server return list with imported pipeline info |
 | 7. | Trigger pipeline run for imported pipeline | Pipeline is triggered |

--- a/docs/md/io/odh/test/e2e/standard/UninstallST.md
+++ b/docs/md/io/odh/test/e2e/standard/UninstallST.md
@@ -1,0 +1,32 @@
+# UninstallST
+
+**Description:** Verifies that uninstall process removes all resources created by ODH installation
+
+**Before tests execution steps:**
+
+| Step | Action | Result |
+| - | - | - |
+| 1. | Deploy Pipelines Operator | Pipelines operator is available on the cluster |
+| 2. | Deploy ServiceMesh Operator | ServiceMesh operator is available on the cluster |
+| 3. | Deploy Serverless Operator | Serverless operator is available on the cluster |
+| 4. | Install ODH operator | Operator is up and running and is able to serve it's operands |
+| 5. | Deploy DSCI | DSCI is created and ready |
+| 6. | Deploy DSC | DSC is created and ready |
+
+<hr style="border:1px solid">
+
+## testUninstallSimpleScenario
+
+**Description:** Check that user can create, run and deleted DataSciencePipeline from a DataScience project
+
+**Contact:** `Jan Stourac <jstourac@redhat.com>`
+
+**Steps:**
+
+| Step | Action | Result |
+| - | - | - |
+| 1. | Create uninstall configmap | ConfigMap exists |
+| 2. | Wait for controllers namespace deletion | Controllers namespace is deleted |
+| 3. | Remove Operator namespace | Operator namespace is deleted |
+| 4. | Check that all related namespaces are deleted (monitoring, notebooks, controllers) | All related namespaces are deleted |
+

--- a/docs/md/io/odh/test/e2e/upgrade/BundleUpgradeST.md
+++ b/docs/md/io/odh/test/e2e/upgrade/BundleUpgradeST.md
@@ -26,7 +26,7 @@
 
 **Description:** Creates default DSCI and DSC and see if operator configure everything properly. Check that operator set status of the resources properly.
 
-**Contact:** `Jakub Stejskal <jstejska@redhat.com>`
+**Contact:** `David Kornel <dkornel@redhat.com>`
 
 **Steps:**
 

--- a/docs/md/io/odh/test/e2e/upgrade/BundleUpgradeST.md
+++ b/docs/md/io/odh/test/e2e/upgrade/BundleUpgradeST.md
@@ -1,0 +1,47 @@
+# BundleUpgradeST
+
+**Description:** Verifies upgrade path from previously released version to latest available build. Operator installation and upgrade is done via bundle of yaml files.
+
+**Before tests execution steps:**
+
+| Step | Action | Result |
+| - | - | - |
+| 1. | Deploy Pipelines Operator | Pipelines operator is available on the cluster |
+| 2. | Deploy ServiceMesh Operator | ServiceMesh operator is available on the cluster |
+| 3. | Deploy Serverless Operator | Serverless operator is available on the cluster |
+
+**After tests execution steps:**
+
+| Step | Action | Result |
+| - | - | - |
+| 1. | Delete all ODH related resources in the cluster | All ODH related resources are gone |
+
+**Tags:**
+
+* `bundle-upgrade`
+
+<hr style="border:1px solid">
+
+## testUpgradeBundle
+
+**Description:** Creates default DSCI and DSC and see if operator configure everything properly. Check that operator set status of the resources properly.
+
+**Contact:** `Jakub Stejskal <jstejska@redhat.com>`
+
+**Steps:**
+
+| Step | Action | Result |
+| - | - | - |
+| 1. | Install operator via bundle of yaml files with specific version | Operator is up and running |
+| 2. | Deploy DSC (see UpgradeAbstract for more info) | DSC is created and ready |
+| 3. | Deploy Notebook to namespace test-odh-notebook-upgrade | All related pods are up and running. Notebook is in ready state. |
+| 4. | Apply latest yaml files with latest Operator version | Yaml file is applied |
+| 5. | Wait for RollingUpdate of Operator pod to a new version | Operator update is finished and pod is up and running |
+| 6. | Verify that Dashboard pods are stable for 2 minutes | Dashboard pods are stable por 2 minutes after upgrade |
+| 7. | Verify that Notebook pods are stable for 2 minutes | Notebook pods are stable por 2 minutes after upgrade |
+| 8. | Check that ODH operator doesn't contain any error logs | ODH operator log is error free |
+
+**Tags:**
+
+* `bundle-upgrade`
+

--- a/docs/md/io/odh/test/e2e/upgrade/OlmUpgradeST.md
+++ b/docs/md/io/odh/test/e2e/upgrade/OlmUpgradeST.md
@@ -1,0 +1,41 @@
+# OlmUpgradeST
+
+**Description:** Verifies upgrade path from previously released version to latest available build. Operator installation and upgrade is done via OLM.
+
+**Before tests execution steps:**
+
+| Step | Action | Result |
+| - | - | - |
+| 1. | Deploy Pipelines Operator | Pipelines operator is available on the cluster |
+| 2. | Deploy ServiceMesh Operator | ServiceMesh operator is available on the cluster |
+| 3. | Deploy Serverless Operator | Serverless operator is available on the cluster |
+
+**Tags:**
+
+* `olm-upgrade`
+
+<hr style="border:1px solid">
+
+## testUpgradeOlm
+
+**Description:** Creates default DSCI and DSC and see if operator configure everything properly. Check that operator set status of the resources properly.
+
+**Contact:** `Jakub Stejskal <jstejska@redhat.com>`
+
+**Steps:**
+
+| Step | Action | Result |
+| - | - | - |
+| 1. | Install operator via OLM with manual approval and specific version | Operator is up and running |
+| 2. | Deploy DSC (see UpgradeAbstract for more info) | DSC is created and ready |
+| 3. | Deploy Notebook to namespace test-odh-notebook-upgrade | All related pods are up and running. Notebook is in ready state. |
+| 4. | Approve install plan for new version | Install plan is approved |
+| 5. | Wait for RollingUpdate of Operator pod to a new version | Operator update is finished and pod is up and running |
+| 6. | Verify that Dashboard pods are stable for 2 minutes | Dashboard pods are stable por 2 minutes after upgrade |
+| 7. | Verify that Notebook pods are stable for 2 minutes | Notebook pods are stable por 2 minutes after upgrade |
+| 8. | Check that ODH operator doesn't contain any error logs | ODH operator log is error free |
+
+**Tags:**
+
+* `olm-upgrade`
+

--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,7 @@
         <maven.download.plugin.version>1.7.1</maven.download.plugin.version>
         <commons.io.version>2.15.1</commons.io.version>
         <jsr305.version>3.0.2</jsr305.version>
+        <docs.generator.version>0.0.4-SNAPSHOT</docs.generator.version>
     </properties>
 
     <repositories>
@@ -176,6 +177,11 @@
             <version>${jsr305.version}</version>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>io.skodjob</groupId>
+            <artifactId>test-docs-generator-maven-plugin</artifactId>
+            <version>${docs.generator.version}</version>
+        </dependency>
     </dependencies>
 
     <build>
@@ -292,11 +298,43 @@
                     <skipCache>true</skipCache>
                 </configuration>
             </plugin>
+
+            <plugin>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>copy-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.directory}/lib</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>io.skodjob</groupId>
+                <artifactId>test-docs-generator-maven-plugin</artifactId>
+                <version>${docs.generator.version}</version>
+                <executions>
+                    <execution>
+                        <phase>post-integration-test</phase>
+                        <goals>
+                            <goal>test-docs-generator</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <testsPath>./src/test/java/io/odh/test</testsPath>
+                    <docsPath>./docs/</docsPath>
+                    <generateFmf>false</generateFmf>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 
     <profiles>
-
         <profile>
             <id>none</id>
             <properties>

--- a/src/test/java/io/odh/test/e2e/standard/DataScienceClusterST.java
+++ b/src/test/java/io/odh/test/e2e/standard/DataScienceClusterST.java
@@ -18,12 +18,33 @@ import io.opendatahub.datasciencecluster.v1.datascienceclusterspec.components.Mo
 import io.opendatahub.datasciencecluster.v1.datascienceclusterspec.components.Ray;
 import io.opendatahub.datasciencecluster.v1.datascienceclusterspec.components.Workbenches;
 import io.opendatahub.dscinitialization.v1.DSCInitialization;
+import io.skodjob.annotations.Contact;
+import io.skodjob.annotations.Desc;
+import io.skodjob.annotations.Step;
+import io.skodjob.annotations.SuiteDoc;
+import io.skodjob.annotations.TestDoc;
+import io.skodjob.annotations.TestTag;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+@SuiteDoc(
+    description = @Desc("Verifies simple setup of ODH by spin-up operator, setup DSCI, and setup DSC."),
+    beforeTestSteps = {
+        @Step(value = "Deploy Pipelines Operator", expected = "Pipelines operator is available on the cluster"),
+        @Step(value = "Deploy ServiceMesh Operator", expected = "ServiceMesh operator is available on the cluster"),
+        @Step(value = "Deploy Serverless Operator", expected = "Serverless operator is available on the cluster"),
+        @Step(value = "Install ODH operator", expected = "Operator is up and running and is able to serve it's operands")
+    },
+    afterTestSteps = {
+        @Step(value = "Delete ODH operator and all created resources", expected = "Operator is removed and all other resources as well")
+    },
+    tags = {
+        @TestTag(value = TestSuite.SMOKE)
+    }
+)
 @Tag(TestSuite.SMOKE)
 @DisabledIfEnvironmentVariable(
         named = Environment.SKIP_DEPLOY_DSCI_DSC_ENV,
@@ -33,6 +54,18 @@ public class DataScienceClusterST extends StandardAbstract {
 
     private static final String DS_PROJECT_NAME = "test-dsp";
 
+    @TestDoc(
+        description = @Desc("Creates default DSCI and DSC and see if operator configure everything properly. Check that operator set status of the resources properly."),
+        contact = @Contact(name = "David Kornel", email = "dkornel@redhat.com"),
+        steps = {
+            @Step(value = "Create default DSCI", expected = "DSCI is created and ready"),
+            @Step(value = "Create default DSC", expected = "DSC is created and ready"),
+            @Step(value = "Check that DSC has expected states for all components", expected = "DSC status is set properly based on configuration")
+        },
+        tags = {
+            @TestTag(value = TestSuite.SMOKE)
+        }
+    )
     @Test
     void createDataScienceCluster() {
 

--- a/src/test/java/io/odh/test/e2e/standard/NotebookST.java
+++ b/src/test/java/io/odh/test/e2e/standard/NotebookST.java
@@ -35,6 +35,11 @@ import io.opendatahub.datasciencecluster.v1.datascienceclusterspec.components.Ra
 import io.opendatahub.datasciencecluster.v1.datascienceclusterspec.components.Workbenches;
 import io.opendatahub.datasciencecluster.v1.datascienceclusterspec.components.WorkbenchesBuilder;
 import io.opendatahub.dscinitialization.v1.DSCInitialization;
+import io.skodjob.annotations.Contact;
+import io.skodjob.annotations.Desc;
+import io.skodjob.annotations.Step;
+import io.skodjob.annotations.SuiteDoc;
+import io.skodjob.annotations.TestDoc;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.kubeflow.v1.Notebook;
@@ -45,6 +50,20 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.util.Map;
 
+@SuiteDoc(
+    description = @Desc("Verifies deployments of Notebooks via GitOps approach"),
+    beforeTestSteps = {
+        @Step(value = "Deploy Pipelines Operator", expected = "Pipelines operator is available on the cluster"),
+        @Step(value = "Deploy ServiceMesh Operator", expected = "ServiceMesh operator is available on the cluster"),
+        @Step(value = "Deploy Serverless Operator", expected = "Serverless operator is available on the cluster"),
+        @Step(value = "Install ODH operator", expected = "Operator is up and running and is able to serve it's operands"),
+        @Step(value = "Deploy DSCI", expected = "DSCI is created and ready"),
+        @Step(value = "Deploy DSC", expected = "DSC is created and ready")
+    },
+    afterTestSteps = {
+        @Step(value = "Delete ODH operator and all created resources", expected = "Operator is removed and all other resources as well")
+    }
+)
 public class NotebookST extends StandardAbstract {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(NotebookST.class);
@@ -53,6 +72,17 @@ public class NotebookST extends StandardAbstract {
 
     private static final String NTB_NAME = "test-odh-notebook";
     private static final String NTB_NAMESPACE = "test-odh-notebook";
+
+    @TestDoc(
+        description = @Desc("Create simple Notebook with all needed resources and see if Operator creates it properly"),
+        contact = @Contact(name = "Jakub Stejskal", email = "jstejska@redhat.com"),
+        steps = {
+            @Step(value = "Create namespace for Notebook resources with proper name, labels and annotations", expected = "Namespace is created"),
+            @Step(value = "Create PVC with proper labels and data for Notebook", expected = "PVC is created"),
+            @Step(value = "Create Notebook resource with Pytorch image in pre-defined namespace", expected = "Notebook resource is created"),
+            @Step(value = "Wait for Notebook pods readiness", expected = "Notebook pods are up and running, Notebook is in ready state")
+        }
+    )
     @Test
     void testCreateSimpleNotebook() throws IOException {
         // Create namespace

--- a/src/test/java/io/odh/test/e2e/standard/PipelineServerST.java
+++ b/src/test/java/io/odh/test/e2e/standard/PipelineServerST.java
@@ -34,6 +34,11 @@ import io.opendatahub.datasciencepipelinesapplications.v1alpha1.DataSciencePipel
 import io.opendatahub.datasciencepipelinesapplications.v1alpha1.DataSciencePipelinesApplicationBuilder;
 import io.opendatahub.datasciencepipelinesapplications.v1alpha1.datasciencepipelinesapplicationspec.ApiServer;
 import io.opendatahub.dscinitialization.v1.DSCInitialization;
+import io.skodjob.annotations.Contact;
+import io.skodjob.annotations.Desc;
+import io.skodjob.annotations.Step;
+import io.skodjob.annotations.SuiteDoc;
+import io.skodjob.annotations.TestDoc;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
@@ -49,6 +54,20 @@ import java.util.stream.Stream;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 
+@SuiteDoc(
+    description = @Desc("Verifies simple setup of ODH by spin-up operator, setup DSCI, and setup DSC."),
+    beforeTestSteps = {
+        @Step(value = "Deploy Pipelines Operator", expected = "Pipelines operator is available on the cluster"),
+        @Step(value = "Deploy ServiceMesh Operator", expected = "ServiceMesh operator is available on the cluster"),
+        @Step(value = "Deploy Serverless Operator", expected = "Serverless operator is available on the cluster"),
+        @Step(value = "Install ODH operator", expected = "Operator is up and running and is able to serve it's operands"),
+        @Step(value = "Deploy DSCI", expected = "DSCI is created and ready"),
+        @Step(value = "Deploy DSC", expected = "DSC is created and ready")
+    },
+    afterTestSteps = {
+        @Step(value = "Delete ODH operator and all created resources", expected = "Operator is removed and all other resources as well")
+    }
+)
 @ExtendWith(ResourceManagerDeleteHandler.class)
 public class PipelineServerST extends StandardAbstract {
     private static final Logger LOGGER = LoggerFactory.getLogger(PipelineServerST.class);
@@ -77,6 +96,22 @@ public class PipelineServerST extends StandardAbstract {
     /// ODS-2206 - Verify user can create and run a data science pipeline in DS Project
     /// ODS-2226 - Verify user can delete components of data science pipeline from DS Pipelines page
     /// https://issues.redhat.com/browse/RHODS-5133
+    @TestDoc(
+        description = @Desc("Check that user can create, run and deleted DataSciencePipeline from a DataScience project"),
+        contact = @Contact(name = "Jiri Danek", email = "jdanek@redhat.com"),
+        steps = {
+            @Step(value = "Create namespace for DataSciencePipelines application with proper name, labels and annotations", expected = "Namespace is created"),
+            @Step(value = "Create Minio secret with proper data for access s3", expected = "Secret is created"),
+            @Step(value = "Create DataSciencePipelines application with configuration for new Minio instance and new MariaDB instance", expected = "Notebook resource is created"),
+            @Step(value = "Wait for DataSciencePipelines server readiness", expected = "DSPA endpoint is available and it return proper data"),
+            @Step(value = "Import pipeline to a pipeline server via API", expected = "Pipeline is imported"),
+            @Step(value = "List imported pipeline via API", expected = "Server return list with imported pipeline info"),
+            @Step(value = "Trigger pipeline run for imported pipeline", expected = "Pipeline is triggered"),
+            @Step(value = "Wait for pipeline success", expected = "Pipeline succeeded"),
+            @Step(value = "Delete pipeline run", expected = "Pipeline run is deleted"),
+            @Step(value = "Delete pipeline", expected = "Pipeline is deleted"),
+        }
+    )
     @Test
     void testUserCanCreateRunAndDeleteADSPipelineFromDSProject() throws IOException {
         OpenShiftClient ocClient = (OpenShiftClient) client;

--- a/src/test/java/io/odh/test/e2e/standard/PipelineServerST.java
+++ b/src/test/java/io/odh/test/e2e/standard/PipelineServerST.java
@@ -102,8 +102,8 @@ public class PipelineServerST extends StandardAbstract {
         steps = {
             @Step(value = "Create namespace for DataSciencePipelines application with proper name, labels and annotations", expected = "Namespace is created"),
             @Step(value = "Create Minio secret with proper data for access s3", expected = "Secret is created"),
-            @Step(value = "Create DataSciencePipelines application with configuration for new Minio instance and new MariaDB instance", expected = "Notebook resource is created"),
-            @Step(value = "Wait for DataSciencePipelines server readiness", expected = "DSPA endpoint is available and it return proper data"),
+            @Step(value = "Create DataSciencePipelinesApplication with configuration for new Minio instance and new MariaDB instance", expected = "DataSciencePipelinesApplication resource is created"),
+            @Step(value = "Wait for DataSciencePipelines server readiness", expected = "DSP API endpoint is available and it return proper data"),
             @Step(value = "Import pipeline to a pipeline server via API", expected = "Pipeline is imported"),
             @Step(value = "List imported pipeline via API", expected = "Server return list with imported pipeline info"),
             @Step(value = "Trigger pipeline run for imported pipeline", expected = "Pipeline is triggered"),

--- a/src/test/java/io/odh/test/e2e/standard/UninstallST.java
+++ b/src/test/java/io/odh/test/e2e/standard/UninstallST.java
@@ -16,12 +16,28 @@ import io.odh.test.utils.DscUtils;
 import io.odh.test.utils.NamespaceUtils;
 import io.opendatahub.datasciencecluster.v1.DataScienceCluster;
 import io.opendatahub.dscinitialization.v1.DSCInitialization;
+import io.skodjob.annotations.Contact;
+import io.skodjob.annotations.Desc;
+import io.skodjob.annotations.Step;
+import io.skodjob.annotations.SuiteDoc;
+import io.skodjob.annotations.TestDoc;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
 
+@SuiteDoc(
+    description = @Desc("Verifies that uninstall process removes all resources created by ODH installation"),
+    beforeTestSteps = {
+        @Step(value = "Deploy Pipelines Operator", expected = "Pipelines operator is available on the cluster"),
+        @Step(value = "Deploy ServiceMesh Operator", expected = "ServiceMesh operator is available on the cluster"),
+        @Step(value = "Deploy Serverless Operator", expected = "Serverless operator is available on the cluster"),
+        @Step(value = "Install ODH operator", expected = "Operator is up and running and is able to serve it's operands"),
+        @Step(value = "Deploy DSCI", expected = "DSCI is created and ready"),
+        @Step(value = "Deploy DSC", expected = "DSC is created and ready")
+    }
+)
 @Disabled("Disabled because of the https://issues.redhat.com/browse/RHOAIENG-499")
 @DisabledIfEnvironmentVariable(
         named = Environment.SKIP_DEPLOY_DSCI_DSC_ENV,
@@ -41,6 +57,16 @@ public class UninstallST extends StandardAbstract {
      *
      * Known issue <a href="https://issues.redhat.com/browse/RHOAIENG-499">RHOAIENG-499</a>
      */
+    @TestDoc(
+        description = @Desc("Check that user can create, run and deleted DataSciencePipeline from a DataScience project"),
+        contact = @Contact(name = "Jan Stourac", email = "jstourac@redhat.com"),
+        steps = {
+            @Step(value = "Create uninstall configmap", expected = "ConfigMap exists"),
+            @Step(value = "Wait for controllers namespace deletion", expected = "Controllers namespace is deleted"),
+            @Step(value = "Remove Operator namespace", expected = "Operator namespace is deleted"),
+            @Step(value = "Check that all related namespaces are deleted (monitoring, notebooks, controllers)", expected = "All related namespaces are deleted")
+        }
+    )
     @Test
     void testUninstallSimpleScenario() {
         if (!ResourceManager.getKubeCmdClient().namespace(OdhConstants.OLM_OPERATOR_NAMESPACE)

--- a/src/test/java/io/odh/test/e2e/upgrade/BundleUpgradeST.java
+++ b/src/test/java/io/odh/test/e2e/upgrade/BundleUpgradeST.java
@@ -14,6 +14,12 @@ import io.odh.test.install.BundleInstall;
 import io.odh.test.utils.DeploymentUtils;
 import io.odh.test.utils.PodUtils;
 import io.odh.test.utils.UpgradeUtils;
+import io.skodjob.annotations.Contact;
+import io.skodjob.annotations.Desc;
+import io.skodjob.annotations.Step;
+import io.skodjob.annotations.SuiteDoc;
+import io.skodjob.annotations.TestDoc;
+import io.skodjob.annotations.TestTag;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -24,6 +30,20 @@ import java.io.IOException;
 import java.util.Date;
 import java.util.Map;
 
+@SuiteDoc(
+    description = @Desc("Verifies upgrade path from previously released version to latest available build. Operator installation and upgrade is done via bundle of yaml files."),
+    beforeTestSteps = {
+        @Step(value = "Deploy Pipelines Operator", expected = "Pipelines operator is available on the cluster"),
+        @Step(value = "Deploy ServiceMesh Operator", expected = "ServiceMesh operator is available on the cluster"),
+        @Step(value = "Deploy Serverless Operator", expected = "Serverless operator is available on the cluster")
+    },
+    afterTestSteps = {
+        @Step(value = "Delete all ODH related resources in the cluster", expected = "All ODH related resources are gone")
+    },
+    tags = {
+        @TestTag(value = TestSuite.BUNDLE_UPGRADE)
+    }
+)
 @Tag(TestSuite.BUNDLE_UPGRADE)
 public class BundleUpgradeST extends UpgradeAbstract {
 
@@ -39,6 +59,23 @@ public class BundleUpgradeST extends UpgradeAbstract {
         }
     }
 
+    @TestDoc(
+        description = @Desc("Creates default DSCI and DSC and see if operator configure everything properly. Check that operator set status of the resources properly."),
+        contact = @Contact(name = "Jakub Stejskal", email = "jstejska@redhat.com"),
+        steps = {
+            @Step(value = "Install operator via bundle of yaml files with specific version", expected = "Operator is up and running"),
+            @Step(value = "Deploy DSC (see UpgradeAbstract for more info)", expected = "DSC is created and ready"),
+            @Step(value = "Deploy Notebook to namespace test-odh-notebook-upgrade", expected = "All related pods are up and running. Notebook is in ready state."),
+            @Step(value = "Apply latest yaml files with latest Operator version", expected = "Yaml file is applied"),
+            @Step(value = "Wait for RollingUpdate of Operator pod to a new version", expected = "Operator update is finished and pod is up and running"),
+            @Step(value = "Verify that Dashboard pods are stable for 2 minutes", expected = "Dashboard pods are stable por 2 minutes after upgrade"),
+            @Step(value = "Verify that Notebook pods are stable for 2 minutes", expected = "Notebook pods are stable por 2 minutes after upgrade"),
+            @Step(value = "Check that ODH operator doesn't contain any error logs", expected = "ODH operator log is error free")
+        },
+        tags = {
+            @TestTag(value = TestSuite.BUNDLE_UPGRADE)
+        }
+    )
     @Test
     void testUpgradeBundle() throws IOException {
         LOGGER.info("Install base version");

--- a/src/test/java/io/odh/test/e2e/upgrade/BundleUpgradeST.java
+++ b/src/test/java/io/odh/test/e2e/upgrade/BundleUpgradeST.java
@@ -61,7 +61,7 @@ public class BundleUpgradeST extends UpgradeAbstract {
 
     @TestDoc(
         description = @Desc("Creates default DSCI and DSC and see if operator configure everything properly. Check that operator set status of the resources properly."),
-        contact = @Contact(name = "Jakub Stejskal", email = "jstejska@redhat.com"),
+        contact = @Contact(name = "David Kornel", email = "dkornel@redhat.com"),
         steps = {
             @Step(value = "Install operator via bundle of yaml files with specific version", expected = "Operator is up and running"),
             @Step(value = "Deploy DSC (see UpgradeAbstract for more info)", expected = "DSC is created and ready"),

--- a/src/test/java/io/odh/test/e2e/upgrade/OlmUpgradeST.java
+++ b/src/test/java/io/odh/test/e2e/upgrade/OlmUpgradeST.java
@@ -16,6 +16,12 @@ import io.odh.test.platform.KubeUtils;
 import io.odh.test.utils.DeploymentUtils;
 import io.odh.test.utils.PodUtils;
 import io.odh.test.utils.UpgradeUtils;
+import io.skodjob.annotations.Contact;
+import io.skodjob.annotations.Desc;
+import io.skodjob.annotations.Step;
+import io.skodjob.annotations.SuiteDoc;
+import io.skodjob.annotations.TestDoc;
+import io.skodjob.annotations.TestTag;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
@@ -25,6 +31,17 @@ import java.io.IOException;
 import java.util.Date;
 import java.util.Map;
 
+@SuiteDoc(
+    description = @Desc("Verifies upgrade path from previously released version to latest available build. Operator installation and upgrade is done via OLM."),
+    beforeTestSteps = {
+        @Step(value = "Deploy Pipelines Operator", expected = "Pipelines operator is available on the cluster"),
+        @Step(value = "Deploy ServiceMesh Operator", expected = "ServiceMesh operator is available on the cluster"),
+        @Step(value = "Deploy Serverless Operator", expected = "Serverless operator is available on the cluster")
+    },
+    tags = {
+        @TestTag(value = TestSuite.OLM_UPGRADE)
+    }
+)
 @Tag(TestSuite.OLM_UPGRADE)
 public class OlmUpgradeST extends UpgradeAbstract {
 
@@ -33,6 +50,23 @@ public class OlmUpgradeST extends UpgradeAbstract {
 
     private final String startingVersion = Environment.OLM_UPGRADE_STARTING_VERSION;
 
+    @TestDoc(
+        description = @Desc("Creates default DSCI and DSC and see if operator configure everything properly. Check that operator set status of the resources properly."),
+        contact = @Contact(name = "Jakub Stejskal", email = "jstejska@redhat.com"),
+        steps = {
+            @Step(value = "Install operator via OLM with manual approval and specific version", expected = "Operator is up and running"),
+            @Step(value = "Deploy DSC (see UpgradeAbstract for more info)", expected = "DSC is created and ready"),
+            @Step(value = "Deploy Notebook to namespace test-odh-notebook-upgrade", expected = "All related pods are up and running. Notebook is in ready state."),
+            @Step(value = "Approve install plan for new version", expected = "Install plan is approved"),
+            @Step(value = "Wait for RollingUpdate of Operator pod to a new version", expected = "Operator update is finished and pod is up and running"),
+            @Step(value = "Verify that Dashboard pods are stable for 2 minutes", expected = "Dashboard pods are stable por 2 minutes after upgrade"),
+            @Step(value = "Verify that Notebook pods are stable for 2 minutes", expected = "Notebook pods are stable por 2 minutes after upgrade"),
+            @Step(value = "Check that ODH operator doesn't contain any error logs", expected = "ODH operator log is error free")
+        },
+        tags = {
+            @TestTag(value = TestSuite.OLM_UPGRADE)
+        }
+    )
     @Test
     void testUpgradeOlm() throws IOException, InterruptedException {
         String ntbName = "test-odh-notebook";


### PR DESCRIPTION
Testing docs will live in `docs` directory. 
`md` sub-directory is generated by the plugin atm.
`fmf` sub-directory is missing, because we do not generate fmf format atm, but can be enabled in the future.
We can also add `usecases` sub-directory with high-level usecases for the ODH that should be covered by test cases (see [this](https://github.com/skodjob/test-metadata-generator/tree/main/docs/usecases))

Note that the plugin and this PR could change so every comment or ideas for improvements are welcome!