### PR TITLE
Switch from pytorch to jupyter-minimal image in notebook tests

### DIFF
--- a/src/main/java/io/odh/test/framework/manager/resources/NotebookResource.java
+++ b/src/main/java/io/odh/test/framework/manager/resources/NotebookResource.java
@@ -26,18 +26,18 @@ import org.apache.commons.io.IOUtils;
 public class NotebookResource implements ResourceType<Notebook> {
 
     private static final String REGISTRY_PATH = "image-registry.openshift-image-registry.svc:5000";
-    public static final String PYTORCH_IMAGE = "pytorch";
-    public static final String PYTORCH_2023_2_TAG = "2023.2";
+    public static final String JUPYTER_MINIMAL_IMAGE = "jupyter-minimal-notebook";
+    public static final String JUPYTER_MINIMAL_2023_2_TAG = "2023.2";
     private static final Map<String, String> ODH_IMAGES_MAP;
 
     static {
-        ODH_IMAGES_MAP = Map.<String, String>of(PYTORCH_IMAGE, "jupyter-pytorch-notebook");
+        ODH_IMAGES_MAP = Map.<String, String>of(JUPYTER_MINIMAL_IMAGE, "jupyter-minimal-notebook");
     }
 
     private static final Map<String, String> RHOAI_IMAGES_MAP;
 
     static {
-        RHOAI_IMAGES_MAP = Map.<String, String>of(PYTORCH_IMAGE, "pytorch");
+        RHOAI_IMAGES_MAP = Map.<String, String>of(JUPYTER_MINIMAL_IMAGE, "s2i-minimal-notebook");
     }
     private static final String NOTEBOOK_TEMPLATE_PATH = "notebook.yaml";
     @Override

--- a/src/test/java/io/odh/test/e2e/standard/NotebookST.java
+++ b/src/test/java/io/odh/test/e2e/standard/NotebookST.java
@@ -111,7 +111,7 @@ public class NotebookST extends StandardAbstract {
                 .build();
         ResourceManager.getInstance().createResourceWithoutWait(pvc);
 
-        String notebookImage = NotebookResource.getNotebookImage(NotebookResource.PYTORCH_IMAGE, NotebookResource.PYTORCH_2023_2_TAG);
+        String notebookImage = NotebookResource.getNotebookImage(NotebookResource.JUPYTER_MINIMAL_IMAGE, NotebookResource.JUPYTER_MINIMAL_2023_2_TAG);
         Notebook notebook = new NotebookBuilder(NotebookResource.loadDefaultNotebook(NTB_NAMESPACE, NTB_NAME, notebookImage)).build();
         ResourceManager.getInstance().createResourceWithoutWait(notebook);
 

--- a/src/test/java/io/odh/test/e2e/upgrade/UpgradeAbstract.java
+++ b/src/test/java/io/odh/test/e2e/upgrade/UpgradeAbstract.java
@@ -114,7 +114,7 @@ public abstract class UpgradeAbstract extends Abstract {
                 .build();
         ResourceManager.getInstance().createResourceWithoutWait(pvc);
 
-        String notebookImage = NotebookResource.getNotebookImage(NotebookResource.PYTORCH_IMAGE, NotebookResource.PYTORCH_2023_2_TAG);
+        String notebookImage = NotebookResource.getNotebookImage(NotebookResource.JUPYTER_MINIMAL_IMAGE, NotebookResource.JUPYTER_MINIMAL_2023_2_TAG);
         Notebook notebook = new NotebookBuilder(NotebookResource.loadDefaultNotebook(namespace, name, notebookImage)).build();
         if (!Environment.PRODUCT.equals(Environment.PRODUCT_DEFAULT)) {
             notebook = new NotebookBuilder(NotebookResource.loadDefaultNotebook(namespace, name, notebookImage))


### PR DESCRIPTION
The pytorch image is large and consumes bandwidth and disk space.
Test runs 5 minutes faster as a result, from about 6 mins to about 1 min.