### PR TITLE
Let's have a separate global constants for RHOAI and ODH

### DIFF
--- a/src/main/java/io/odh/test/Environment.java
+++ b/src/main/java/io/odh/test/Environment.java
@@ -69,12 +69,13 @@ public class Environment {
     private static final String OPERATOR_INSTALL_TYPE_ENV = "OPERATOR_INSTALL_TYPE";
     private static final String OLM_UPGRADE_STARTING_VERSION_ENV = "OLM_UPGRADE_STARTING_VERSION";
 
-    public static final String PRODUCT_DEFAULT = "odh";
+    public static final String PRODUCT_ODH = "odh";
+    public static final String PRODUCT_RHOAI = "rhoai";
 
     /**
      * Set values
      */
-    public static final String PRODUCT = getOrDefault(PRODUCT_ENV, PRODUCT_DEFAULT);
+    public static final String PRODUCT = getOrDefault(PRODUCT_ENV, PRODUCT_ODH);
     public static final String RUN_USER = getOrDefault("USER", null);
     public static final String KUBE_USERNAME = getOrDefault(USERNAME_ENV, null);
     public static final String KUBE_PASSWORD = getOrDefault(PASSWORD_ENV, null);

--- a/src/main/java/io/odh/test/OdhConstants.java
+++ b/src/main/java/io/odh/test/OdhConstants.java
@@ -87,7 +87,7 @@ public class OdhConstants {
 
     private static <T> T getOdhOrRhoai(String var, T odhValue, T rhoaiValue) {
         T returnValue = odhValue;
-        if (!Objects.equals(Environment.PRODUCT, Environment.PRODUCT_DEFAULT)) {
+        if (!Objects.equals(Environment.PRODUCT, Environment.PRODUCT_ODH)) {
             returnValue = rhoaiValue;
         }
         VALUES.put(var, String.valueOf(returnValue));

--- a/src/main/java/io/odh/test/framework/manager/resources/NotebookResource.java
+++ b/src/main/java/io/odh/test/framework/manager/resources/NotebookResource.java
@@ -91,7 +91,7 @@ public class NotebookResource implements ResourceType<Notebook> {
     }
 
     public static String getNotebookImage(String imageName, String imageTag) {
-        if (Objects.equals(Environment.PRODUCT, Environment.PRODUCT_DEFAULT)) {
+        if (Objects.equals(Environment.PRODUCT, Environment.PRODUCT_ODH)) {
             return REGISTRY_PATH + "/" + OdhConstants.CONTROLLERS_NAMESPACE + "/" + ODH_IMAGES_MAP.get(imageName) + ":" + imageTag;
         } else {
             return REGISTRY_PATH + "/" + OdhConstants.CONTROLLERS_NAMESPACE + "/" + RHOAI_IMAGES_MAP.get(imageName) + ":" + imageTag;

--- a/src/test/java/io/odh/test/e2e/continuous/DataScienceClusterST.java
+++ b/src/test/java/io/odh/test/e2e/continuous/DataScienceClusterST.java
@@ -61,7 +61,7 @@ public class DataScienceClusterST extends Abstract {
         assertEquals(Ray.ManagementState.MANAGED, cluster.getSpec().getComponents().getRay().getManagementState());
         assertEquals(Modelmeshserving.ManagementState.MANAGED, cluster.getSpec().getComponents().getModelmeshserving().getManagementState());
         assertEquals(Datasciencepipelines.ManagementState.MANAGED, cluster.getSpec().getComponents().getDatasciencepipelines().getManagementState());
-        if (!Environment.PRODUCT.equals(Environment.PRODUCT_DEFAULT)
+        if (!Environment.PRODUCT.equals(Environment.PRODUCT_ODH)
                 && Environment.OPERATOR_INSTALL_TYPE.equalsIgnoreCase(InstallTypes.OLM.toString())
                 && Objects.requireNonNull(CsvUtils.getOperatorVersionFromCsv()).equals("2.7.0")) {
             // https://issues.redhat.com/browse/RHOAIENG-3234 Remove Kueue from RHOAI 2.7

--- a/src/test/java/io/odh/test/e2e/standard/DataScienceClusterST.java
+++ b/src/test/java/io/odh/test/e2e/standard/DataScienceClusterST.java
@@ -92,7 +92,7 @@ public class DataScienceClusterST extends StandardAbstract {
         assertEquals(Workbenches.ManagementState.MANAGED, cluster.getSpec().getComponents().getWorkbenches().getManagementState());
         assertEquals(Modelmeshserving.ManagementState.MANAGED, cluster.getSpec().getComponents().getModelmeshserving().getManagementState());
         assertEquals(Ray.ManagementState.MANAGED, cluster.getSpec().getComponents().getRay().getManagementState());
-        if (!Environment.PRODUCT.equals(Environment.PRODUCT_DEFAULT)
+        if (!Environment.PRODUCT.equals(Environment.PRODUCT_ODH)
                 && Environment.OPERATOR_INSTALL_TYPE.equalsIgnoreCase(InstallTypes.OLM.toString())
                 && Objects.requireNonNull(CsvUtils.getOperatorVersionFromCsv()).equals("2.7.0")) {
             // https://issues.redhat.com/browse/RHOAIENG-3234 Remove Kueue from RHOAI 2.7

--- a/src/test/java/io/odh/test/e2e/standard/PipelineServerST.java
+++ b/src/test/java/io/odh/test/e2e/standard/PipelineServerST.java
@@ -223,7 +223,7 @@ public class PipelineServerST extends StandardAbstract {
             KFPv1Client kfpv1Client = new KFPv1Client("http://localhost:%d".formatted(portForward.getLocalPort()));
 
             // WORKAROUND(RHOAIENG-3250): delete sample pipeline present on ODH
-            if (Environment.PRODUCT.equals(Environment.PRODUCT_DEFAULT)) {
+            if (Environment.PRODUCT.equals(Environment.PRODUCT_ODH)) {
                 for (KFPv1Client.Pipeline pipeline : kfpv1Client.listPipelines()) {
                     kfpv1Client.deletePipeline(pipeline.id);
                 }

--- a/src/test/java/io/odh/test/e2e/upgrade/UpgradeAbstract.java
+++ b/src/test/java/io/odh/test/e2e/upgrade/UpgradeAbstract.java
@@ -121,7 +121,7 @@ public abstract class UpgradeAbstract extends Abstract {
 
         String notebookImage = NotebookResource.getNotebookImage(NotebookResource.JUPYTER_MINIMAL_IMAGE, NotebookResource.JUPYTER_MINIMAL_2023_2_TAG);
         Notebook notebook = new NotebookBuilder(NotebookResource.loadDefaultNotebook(namespace, name, notebookImage)).build();
-        if (!Environment.PRODUCT.equals(Environment.PRODUCT_DEFAULT)) {
+        if (!Environment.PRODUCT.equals(Environment.PRODUCT_ODH)) {
             notebook = new NotebookBuilder(NotebookResource.loadDefaultNotebook(namespace, name, notebookImage))
                     .editSpec()
                     .editNotebookspecTemplate()


### PR DESCRIPTION
Let's ditch the constant for the default product name and introduce global constants for the RHOAI and ODH instead so we can reference them directly in our tests instead of relying on the default product set.