### PR TITLE
Remove ODH/RHOAI conditional in upgrade test; `getNotebookImage` is perfectly sufficient

### DIFF
--- a/docs/md/io/odh/test/e2e/standard/NotebookST.md
+++ b/docs/md/io/odh/test/e2e/standard/NotebookST.md
@@ -33,6 +33,6 @@
 | - | - | - |
 | 1. | Create namespace for Notebook resources with proper name, labels and annotations | Namespace is created |
 | 2. | Create PVC with proper labels and data for Notebook | PVC is created |
-| 3. | Create Notebook resource with Pytorch image in pre-defined namespace | Notebook resource is created |
+| 3. | Create Notebook resource with Jupyter Minimal image in pre-defined namespace | Notebook resource is created |
 | 4. | Wait for Notebook pods readiness | Notebook pods are up and running, Notebook is in ready state |
 

--- a/src/test/java/io/odh/test/e2e/standard/NotebookST.java
+++ b/src/test/java/io/odh/test/e2e/standard/NotebookST.java
@@ -81,7 +81,7 @@ public class NotebookST extends StandardAbstract {
         steps = {
             @Step(value = "Create namespace for Notebook resources with proper name, labels and annotations", expected = "Namespace is created"),
             @Step(value = "Create PVC with proper labels and data for Notebook", expected = "PVC is created"),
-            @Step(value = "Create Notebook resource with Pytorch image in pre-defined namespace", expected = "Notebook resource is created"),
+            @Step(value = "Create Notebook resource with Jupyter Minimal image in pre-defined namespace", expected = "Notebook resource is created"),
             @Step(value = "Wait for Notebook pods readiness", expected = "Notebook pods are up and running, Notebook is in ready state")
         }
     )

--- a/src/test/java/io/odh/test/e2e/upgrade/UpgradeAbstract.java
+++ b/src/test/java/io/odh/test/e2e/upgrade/UpgradeAbstract.java
@@ -9,7 +9,6 @@ import io.fabric8.kubernetes.api.model.NamespaceBuilder;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaimBuilder;
 import io.fabric8.kubernetes.api.model.Quantity;
-import io.odh.test.Environment;
 import io.odh.test.OdhAnnotationsLabels;
 import io.odh.test.TestSuite;
 import io.odh.test.e2e.Abstract;
@@ -42,7 +41,6 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.kubeflow.v1.Notebook;
 import org.kubeflow.v1.NotebookBuilder;
-import org.kubeflow.v1.notebookspec.template.spec.containers.EnvBuilder;
 
 import java.io.IOException;
 
@@ -121,20 +119,6 @@ public abstract class UpgradeAbstract extends Abstract {
 
         String notebookImage = NotebookResource.getNotebookImage(NotebookResource.JUPYTER_MINIMAL_IMAGE, NotebookResource.JUPYTER_MINIMAL_2023_2_TAG);
         Notebook notebook = new NotebookBuilder(NotebookResource.loadDefaultNotebook(namespace, name, notebookImage)).build();
-        if (!Environment.PRODUCT.equals(Environment.PRODUCT_ODH)) {
-            notebook = new NotebookBuilder(NotebookResource.loadDefaultNotebook(namespace, name, notebookImage))
-                    .editSpec()
-                    .editNotebookspecTemplate()
-                    .editOrNewSpec()
-                    .editContainer(0)
-                    .withImage("image-registry.openshift-image-registry.svc:5000/redhat-ods-applications/pytorch:2023.2")
-                    .addToEnv(new EnvBuilder().withName("JUPYTER_IMAGE").withValue("image-registry.openshift-image-registry.svc:5000/redhat-ods-applications/pytorch:2023.2").build())
-                    .endSpecContainer()
-                    .endTemplateSpec()
-                    .endNotebookspecTemplate()
-                    .endSpec()
-                    .build();
-        }
 
         ResourceManager.getInstance().createResourceWithoutWait(notebook);
     }


### PR DESCRIPTION
There is extra override for notebook image when not on ODH. This should not be there, because the image selection above already considers ODH/RHOAI.

As a consequence, we use the huge pytorch image on RHOAI, which makes upgrade test run long and be unstable.