### PR TITLE
feat: support the necessary configurability for testing odh-nightly builds

### DIFF
--- a/src/main/java/io/odh/test/Environment.java
+++ b/src/main/java/io/odh/test/Environment.java
@@ -48,6 +48,7 @@ public class Environment {
     private static final String SKIP_INSTALL_OPERATOR_DEPS_ENV = "SKIP_INSTALL_OPERATOR_DEPS";
     private static final String SKIP_INSTALL_OPERATOR_ENV = "SKIP_INSTALL_OPERATOR";
     public static final String SKIP_DEPLOY_DSCI_DSC_ENV = "SKIP_DEPLOY_DSCI_DSC";
+    public static final String DEFAULT_DSCI_NAME_ENV = "DEFAULT_DSCI_NAME";
 
     /**
      * Install bundle files
@@ -62,6 +63,7 @@ public class Environment {
     private static final String OLM_SOURCE_NAME_ENV = "OLM_SOURCE_NAME";
     private static final String OLM_SOURCE_NAMESPACE_ENV = "OLM_SOURCE_NAMESPACE";
     private static final String OLM_OPERATOR_VERSION_ENV = "OLM_OPERATOR_VERSION";
+    private static final String OLM_OPERATOR_NAME_ENV = "OLM_OPERATOR_NAME";
     private static final String OLM_OPERATOR_CHANNEL_ENV = "OLM_OPERATOR_CHANNEL";
     private static final String OPERATOR_INSTALL_TYPE_ENV = "OPERATOR_INSTALL_TYPE";
     private static final String OLM_UPGRADE_STARTING_VERSION_ENV = "OLM_UPGRADE_STARTING_VERSION";
@@ -78,6 +80,7 @@ public class Environment {
     public static final boolean SKIP_INSTALL_OPERATOR_DEPS = getOrDefault(SKIP_INSTALL_OPERATOR_DEPS_ENV, Boolean::valueOf, false);
     public static final boolean SKIP_INSTALL_OPERATOR = getOrDefault(SKIP_INSTALL_OPERATOR_ENV, Boolean::valueOf, false);
     public static final boolean SKIP_DEPLOY_DSCI_DSC = getOrDefault(SKIP_DEPLOY_DSCI_DSC_ENV, Boolean::valueOf, false);
+    public static final String DEFAULT_DSCI_NAME = getOrDefault(DEFAULT_DSCI_NAME_ENV, String::valueOf, OdhConstants.DEFAULT_DSCI_NAME);
 
     // YAML Bundle
     public static final String INSTALL_FILE_PATH = getOrDefault(INSTALL_FILE_ENV, TestConstants.LATEST_BUNDLE_DEPLOY_FILE);
@@ -90,6 +93,7 @@ public class Environment {
     public static final String OLM_OPERATOR_CHANNEL = getOrDefault(OLM_OPERATOR_CHANNEL_ENV, OdhConstants.OLM_OPERATOR_CHANNEL);
     public static final String OLM_OPERATOR_VERSION = getOrDefault(OLM_OPERATOR_VERSION_ENV, OdhConstants.OLM_OPERATOR_VERSION);
     public static final String OLM_UPGRADE_STARTING_VERSION = getOrDefault(OLM_UPGRADE_STARTING_VERSION_ENV, OdhConstants.OLM_UPGRADE_STARTING_OPERATOR_VERSION);
+    public static final String OLM_OPERATOR_NAME = getOrDefault(OLM_OPERATOR_NAME_ENV, OdhConstants.OLM_OPERATOR_NAME);
 
     public static final String OPERATOR_INSTALL_TYPE = getOrDefault(OPERATOR_INSTALL_TYPE_ENV, InstallTypes.BUNDLE.toString());
 

--- a/src/main/java/io/odh/test/install/OlmInstall.java
+++ b/src/main/java/io/odh/test/install/OlmInstall.java
@@ -27,13 +27,13 @@ public class OlmInstall {
 
     private String namespace = OdhConstants.OLM_OPERATOR_NAMESPACE;
     private String channel = Environment.OLM_OPERATOR_CHANNEL;
-    private String name = OdhConstants.OLM_OPERATOR_NAME;
-    private String operatorName = OdhConstants.OLM_OPERATOR_NAME;
+    private String name = Environment.OLM_OPERATOR_NAME;
+    private String operatorName = Environment.OLM_OPERATOR_NAME;
     private String sourceName = Environment.OLM_SOURCE_NAME;
     private String sourceNamespace = Environment.OLM_SOURCE_NAMESPACE;
     private String startingCsv;
     private String deploymentName = OdhConstants.OLM_OPERATOR_DEPLOYMENT_NAME;
-    private String olmAppBundlePrefix  = OdhConstants.OLM_OPERATOR_NAME;
+    private String olmAppBundlePrefix  = Environment.OLM_OPERATOR_NAME;
     private String operatorVersion  = Environment.OLM_OPERATOR_VERSION;
     private String csvName = operatorName + "." + operatorVersion;
 
@@ -62,7 +62,7 @@ public class OlmInstall {
      */
     private void createNamespace() {
         if (!KubeResourceManager.getKubeClient().namespaceExists(namespace)) {
-            // Create namespace at first because operator-group and subscription could you specific namespace
+            // Create a namespace first because operator-group and subscription could use specific namespace
             Namespace ns = new NamespaceBuilder()
                 .withNewMetadata()
                 .withName(namespace)

--- a/src/main/java/io/odh/test/utils/DscUtils.java
+++ b/src/main/java/io/odh/test/utils/DscUtils.java
@@ -4,6 +4,7 @@
  */
 package io.odh.test.utils;
 
+import io.odh.test.Environment;
 import io.odh.test.OdhConstants;
 import io.odh.test.framework.manager.requirements.ServiceMeshOperator;
 import io.opendatahub.datasciencecluster.v1.DataScienceCluster;
@@ -37,7 +38,7 @@ public class DscUtils {
     public static DSCInitialization getBasicDSCI() {
         return new DSCInitializationBuilder()
                 .withNewMetadata()
-                .withName(OdhConstants.DEFAULT_DSCI_NAME)
+                .withName(Environment.DEFAULT_DSCI_NAME)
                 .endMetadata()
                 .withNewSpec()
                 .withApplicationsNamespace(OdhConstants.CONTROLLERS_NAMESPACE)

--- a/src/test/java/io/odh/test/e2e/standard/DataScienceClusterST.java
+++ b/src/test/java/io/odh/test/e2e/standard/DataScienceClusterST.java
@@ -80,7 +80,8 @@ public class DataScienceClusterST extends StandardAbstract {
         // Create DSC
         DataScienceCluster c = DscUtils.getBasicDSC(DS_PROJECT_NAME);
 
-        KubeResourceManager.getInstance().createResourceWithWait(dsci);
+        // odh-nightly gives us a default DSCi, update that
+        KubeResourceManager.getInstance().createOrUpdateResourceWithWait(dsci);
         KubeResourceManager.getInstance().createResourceWithWait(c);
 
         DataScienceCluster cluster = DataScienceClusterType.dataScienceCLusterClient().withName(DS_PROJECT_NAME).get();


### PR DESCRIPTION
I can't fully try this because operator in odh-nightlies gets stuck after deleting dsci, but these should be all the changes necessary.

---

The expected settings for running odh-nightly build, which is ODH packaged as if it was RHOAI, are something like

```
PRODUCT=odh
DEFAULT_DSCI_NAME=default-dsci

OPERATOR_INSTALL_TYPE=olm
OLM_SOURCE_NAME=rhoai-source
OLM_OPERATOR_NAME=rhods-operator
OLM_OPERATOR_CHANNEL=odh-nightlies
OLM_SOURCE_NAMESPACE=openshift-marketplace
OLM_OPERATOR_VERSION=1.18.0
```