### PR TITLE
selftests: fix java.io.IOException: HTTP/1.1 header parser received no bytes

### DIFF
--- a/src/test/java/io/odh/test/unit/MultipartFormDataBodyPublisherTests.java
+++ b/src/test/java/io/odh/test/unit/MultipartFormDataBodyPublisherTests.java
@@ -110,7 +110,11 @@ public class MultipartFormDataBodyPublisherTests {
     @Test
     public void testMultipartFormData() throws Exception {
         HttpServer httpd = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
-        new Thread(() -> httpd.start()).start();
+        httpd.createContext("/", httpExchange -> {
+            httpExchange.sendResponseHeaders(200, 0);
+            httpExchange.getResponseBody().close();
+        });
+        httpd.start();
         try {
             MultipartFormDataBodyPublisher publisher = new MultipartFormDataBodyPublisher()
                     .add("key", "value")


### PR DESCRIPTION
First, `HttpServer.start()` already manages threads, no reason to wrap it in `new Thread`.

Second, the docs for HttpServer say that "One or more HttpHandler objects must be associated with a server in order to process requests." When I added one, and implemented the barest minimum, things started to work reliably. The barest minimum for a `HttpExchange` is "5) sendResponseHeaders(int,long) to send the response headers. Must be called before next step. 6) getResponseBody() to get a OutputStream to send the response body. When the response body has been written, the stream must be closed to terminate the exchange."

Checked this by running the selftest 10000 times in a loop, all passed. Previously, I always got a failure after about 500 attempts.

* https://docs.oracle.com/javase/8/docs/jre/api/net/httpserver/spec/com/sun/net/httpserver/HttpServer.html
* https://docs.oracle.com/javase/8/docs/jre/api/net/httpserver/spec/com/sun/net/httpserver/HttpExchange.html

Fixes #146