### PR TITLE
Update test frame to 0.3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <aspectj.version>1.9.21.2</aspectj.version>
         <allure.version>2.27.0</allure.version>
         <allure.maven.version>2.12.0</allure.maven.version>
-        <test-frame.version>0.2.0</test-frame.version>
+        <test-frame.version>0.3.0</test-frame.version>
     </properties>
 
     <repositories>


### PR DESCRIPTION
This update allow to use operator-sdk runner from test-frame to install operators using manifest bundle-image.
ref: https://github.com/skodjob/test-frame/tree/main/test-frame-openshift/src/main/java/io/skodjob/testframe/olm