### PR TITLE
RHOAIENG-14782: Issue #164: Revert "Move to latest test-frame 0.7.0 (#163)"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
 
         <opedatahub-crds.version>1.0.74-SNAPSHOT</opedatahub-crds.version>
         <docs.generator.version>0.2.0</docs.generator.version>
-        <test-frame.version>0.7.0</test-frame.version>
+        <test-frame.version>0.4.0</test-frame.version>
     </properties>
 
     <repositories>


### PR DESCRIPTION
[test-frame 0.5.0](https://github.com/skodjob/test-frame/releases/tag/0.5.0) introduced async deletion of resources. This breaks DSC and DSCi deletion, because DSCi can only be deleted after DSC deletion has completed.

* https://github.com/skodjob/odh-e2e/issues/164

This reverts commit b719c0ec